### PR TITLE
fix placeholders in build.template to reflect input

### DIFF
--- a/build.template
+++ b/build.template
@@ -282,11 +282,11 @@ let githubLink = sprintf "https://github.com/%s/%s" github_release_user gitName
 
 // Specify more information about your project
 let info =
-  [ "project-name", "FSharpGephiStreamer"
-    "project-author", "Timo Mühlhaus"
-    "project-summary", "FSharp functions for streaming graph data to gephi a graph visualization tool"
+  [ "project-name", "##ProjectName##"
+    "project-author", "##Author##"
+    "project-summary", "##Summary##"
     "project-github", githubLink
-    "project-nuget", "http://nuget.org/packages/FSharpGephiStreamer" ]
+    "project-nuget", "http://nuget.org/packages/##ProjectName##" ]
 
 let root = website
 


### PR DESCRIPTION
I noticed that build.template didn't use the correct placeholders to reflect the user input. I replaced the hardcoded strings with the correct placeholders.
